### PR TITLE
CI: build & publish with CONFIG=okc

### DIFF
--- a/.github/workflows/dev-pipeline.yml
+++ b/.github/workflows/dev-pipeline.yml
@@ -235,7 +235,8 @@ jobs:
         run: yarn run test-report
 
   docker-push:
-    if: github.ref == 'refs/heads/v3'
+    # todo: re-add this before merging!
+    # if: github.ref == 'refs/heads/v3'
     needs:
       - lint
       - unit-test
@@ -269,6 +270,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          build-args:
+            # speed up build by not building for all configs
+            CONFIG=okc
           tags: |
             ghcr.io/embarkokc/digitransit-ui:v3
             ghcr.io/embarkokc/digitransit-ui:${{ steps.docker-tags.outputs.permanent-tag }}


### PR DESCRIPTION
Building with `CONFIG=okc` speeds up the CI Docker build *a lot*, but currently, the resulting `digitransit-ui` build does not have (working) styles.