### PR TITLE
Additional route attributes, dynamic fare/schedule urls and fixes

### DIFF
--- a/app/component/ItinerarySummary.js
+++ b/app/component/ItinerarySummary.js
@@ -20,6 +20,10 @@ const ItinerarySummary = ({
     window.print();
   };
 
+  const faresUrl = it => {
+    const transitLegs = it.legs.filter(leg => leg.transitLeg === true);
+    return transitLegs.length > 0 ? transitLegs[0].route.agency.faresUrl : null;
+  };
   return (
     <div className="itinerary-summary">
       {!isMobile && <div className="divider-top" />}
@@ -32,7 +36,10 @@ const ItinerarySummary = ({
           futureText={futureText}
           multiRow={isMultiRow}
         />
-        <TicketInformation fares={itinerary.fares} />
+        <TicketInformation
+          fares={itinerary.fares}
+          faresUrl={faresUrl(itinerary)}
+        />
       </div>
       <div className="itinerary-summary-info-row">
         {walking && walking.distance > 0 && (

--- a/app/component/PatternStopsContainer.js
+++ b/app/component/PatternStopsContainer.js
@@ -106,6 +106,7 @@ export default createFragmentContainer(withBreakpoint(PatternStopsContainer), {
       mode
       type
       url
+      desc
       ...RouteAgencyInfo_route
       ...RoutePatternSelect_route @arguments(date: $date)
       alerts {

--- a/app/component/PatternStopsContainer.js
+++ b/app/component/PatternStopsContainer.js
@@ -105,6 +105,7 @@ export default createFragmentContainer(withBreakpoint(PatternStopsContainer), {
       longName
       mode
       type
+      url
       ...RouteAgencyInfo_route
       ...RoutePatternSelect_route @arguments(date: $date)
       alerts {

--- a/app/component/PrecheckedLink.js
+++ b/app/component/PrecheckedLink.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
  * headers need to be returned by that server.
  */
 const PrecheckedLink = ({ href, children }) => {
-  const [linkVisible, setLinkVisible] = useState(false);
+  const [linkVisible, setLinkVisible] = useState(true);
 
   useEffect(() => {
     axios
@@ -18,11 +18,8 @@ const PrecheckedLink = ({ href, children }) => {
       })
       .catch(error => {
         if (error.response && error.response.status === 404) {
-          // If the request returns a 404 status, hide the link
+          // Iff the request returns a 404 status, hide the link
           setLinkVisible(false);
-        } else {
-          // eslint-disable-next-line no-console
-          console.info('Cannot retrieve url, will hide link:', error);
         }
       });
   }, [href]);

--- a/app/component/RouteAdditionalInfos.js
+++ b/app/component/RouteAdditionalInfos.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+/*
+ * RouteAdditionalInfos renders additional attributes provided
+ * via route desc as rows.
+ */
+const RouteAdditionalInfos = ({ route }) => {
+  if (!route.desc) {
+    return null;
+  }
+  const infos = route.desc.split('|');
+  const rows = infos.map(info => {
+    const keyValue = info.split(/:(.+)/);
+    return (
+      <li key={`add-infos-${keyValue[0]}`}>
+        <b>{keyValue[0]}:</b>
+        {keyValue[1]}
+      </li>
+    );
+  });
+
+  return <ul className="route-additional-infos">{rows}</ul>;
+};
+
+RouteAdditionalInfos.propTypes = {
+  route: PropTypes.object.isRequired,
+};
+
+export default RouteAdditionalInfos;

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -148,7 +148,7 @@ class RoutePage extends React.Component {
 }
 
 // DT-2531: added activeDates
-// EMBARK: Added url for schedule pdf
+// EMBARK: Added url for schedule pdf, desc for additional infos
 const containerComponent = createFragmentContainer(withBreakpoint(RoutePage), {
   route: graphql`
     fragment RoutePage_route on Route
@@ -160,6 +160,7 @@ const containerComponent = createFragmentContainer(withBreakpoint(RoutePage), {
       mode
       type
       url
+      desc
       ...RouteAgencyInfo_route
       ...RoutePatternSelect_route @arguments(date: $date)
       alerts {

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -148,6 +148,7 @@ class RoutePage extends React.Component {
 }
 
 // DT-2531: added activeDates
+// EMBARK: Added url for schedule pdf
 const containerComponent = createFragmentContainer(withBreakpoint(RoutePage), {
   route: graphql`
     fragment RoutePage_route on Route
@@ -158,6 +159,7 @@ const containerComponent = createFragmentContainer(withBreakpoint(RoutePage), {
       longName
       mode
       type
+      url
       ...RouteAgencyInfo_route
       ...RoutePatternSelect_route @arguments(date: $date)
       alerts {

--- a/app/component/RoutePageControlPanel.js
+++ b/app/component/RoutePageControlPanel.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-unresolved */
-import urlTemplate from 'url-template';
 import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -80,6 +79,7 @@ class RoutePageControlPanel extends React.Component {
       agency: PropTypes.shape({
         name: PropTypes.string.isRequired,
       }).isRequired,
+      url: PropTypes.string,
     }).isRequired,
     match: matchShape.isRequired,
     breakpoint: PropTypes.string.isRequired,
@@ -130,6 +130,7 @@ class RoutePageControlPanel extends React.Component {
             layer: `route-${route.mode}`,
             link: location.pathname,
             agency: { name: route.agency.name },
+            url: route.url,
           },
           type: 'Route',
         },
@@ -361,15 +362,6 @@ class RoutePageControlPanel extends React.Component {
     const { breakpoint, match, route, language } = this.props;
     const { patternId } = match.params;
     const { config } = this.context;
-
-    let routePdfUrl = null;
-    if (config.URL.ROUTE_PDF) {
-      const routePdfUrlTemplate = urlTemplate.parse(config.URL.ROUTE_PDF);
-      routePdfUrl = routePdfUrlTemplate.expand({
-        routeShortName: route.shortName,
-      });
-    }
-
     const routeNotifications = [];
     if (
       config.NODE_ENV !== 'test' &&
@@ -493,9 +485,9 @@ class RoutePageControlPanel extends React.Component {
                 className={cx({ 'bp-large': breakpoint === 'large' })}
                 useCurrentTime={useCurrentTime}
               />
-              {routePdfUrl ? (
+              {route.url ? (
                 <span className="okc-pdf-download-button okc-icon-button">
-                  <PrecheckedLink href={routePdfUrl}>
+                  <PrecheckedLink href={route.url}>
                     <Icon img="icon-icon_download" />
                     <span>Map &amp; Schedule PDF</span>
                   </PrecheckedLink>

--- a/app/component/RoutePageControlPanel.js
+++ b/app/component/RoutePageControlPanel.js
@@ -9,6 +9,7 @@ import { matchShape, routerShape } from 'found';
 import { enrichPatterns } from '@digitransit-util/digitransit-util';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import CallAgencyWarning from './CallAgencyWarning';
+import RouteAdditionalInfos from './RouteAdditionalInfos';
 import RoutePatternSelect from './RoutePatternSelect';
 import RouteNotification from './routeNotification';
 import PrecheckedLink from './PrecheckedLink';
@@ -80,6 +81,7 @@ class RoutePageControlPanel extends React.Component {
         name: PropTypes.string.isRequired,
       }).isRequired,
       url: PropTypes.string,
+      desc: PropTypes.string,
     }).isRequired,
     match: matchShape.isRequired,
     breakpoint: PropTypes.string.isRequired,
@@ -131,6 +133,7 @@ class RoutePageControlPanel extends React.Component {
             link: location.pathname,
             agency: { name: route.agency.name },
             url: route.url,
+            desc: route.desc,
           },
           type: 'Route',
         },
@@ -485,6 +488,7 @@ class RoutePageControlPanel extends React.Component {
                 className={cx({ 'bp-large': breakpoint === 'large' })}
                 useCurrentTime={useCurrentTime}
               />
+              <RouteAdditionalInfos route={route} />
               {route.url ? (
                 <span className="okc-pdf-download-button okc-icon-button">
                   <PrecheckedLink href={route.url}>

--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { matchShape, routerShape, RedirectException } from 'found';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { intlShape, FormattedMessage } from 'react-intl';
 import sortBy from 'lodash/sortBy';
 import cx from 'classnames';

--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -1071,6 +1071,7 @@ const containerComponent = createFragmentContainer(
         longName
         mode
         type
+        url
         ...RouteAgencyInfo_route
         ...RoutePatternSelect_route @arguments(date: $date)
         alerts {

--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -1072,6 +1072,7 @@ const containerComponent = createFragmentContainer(
         mode
         type
         url
+        desc
         ...RouteAgencyInfo_route
         ...RoutePatternSelect_route @arguments(date: $date)
         alerts {

--- a/app/component/RouteTitle.js
+++ b/app/component/RouteTitle.js
@@ -41,6 +41,7 @@ export default createFragmentContainer(withBreakpoint(RouteTitle), {
       color
       mode
       type
+      url
     }
   `,
 });

--- a/app/component/TicketInformation.okc.js
+++ b/app/component/TicketInformation.okc.js
@@ -4,7 +4,7 @@ import { intlShape } from 'react-intl';
 import Icon from './Icon';
 import { FareShape } from '../util/shapes';
 
-export default function TicketInformation({ fares }, { intl, config }) {
+export default function TicketInformation({ fares, faresUrl }, { intl }) {
   if (!fares || fares.length !== 1 || !fares[0].cents) {
     // FOR EMBARK, we assume that exactly one fare is returned.
     // Should there be more than one, we better show nothing, than
@@ -12,7 +12,6 @@ export default function TicketInformation({ fares }, { intl, config }) {
     return null;
   }
 
-  const buyTicketUrl = config.URL?.BUY_TICKET_URL;
   return (
     <span className="okc-icon-button fare--itinerary-summary">
       <Icon img="icon-icon_ticket" />
@@ -22,22 +21,23 @@ export default function TicketInformation({ fares }, { intl, config }) {
           currency: 'USD',
         })}
       </span>
-      <a href={buyTicketUrl}>Buy</a>
+      <a href={faresUrl}>Buy</a>
     </span>
   );
 }
 
 TicketInformation.propTypes = {
   fares: PropTypes.arrayOf(FareShape),
+  faresUrl: PropTypes.string,
 };
 
 TicketInformation.defaultProps = {
   fares: [],
+  faresUrl: null,
 };
 
 TicketInformation.contextTypes = {
   intl: intlShape,
-  config: PropTypes.object.isRequired,
 };
 
 TicketInformation.displayName = 'TicketInformation';

--- a/app/component/TripStopsContainer.js
+++ b/app/component/TripStopsContainer.js
@@ -107,6 +107,7 @@ const containerComponent = createFragmentContainer(pureComponent, {
       mode
       type
       url
+      desc
       ...RouteAgencyInfo_route
       ...RoutePatternSelect_route @arguments(date: $date)
       alerts {

--- a/app/component/TripStopsContainer.js
+++ b/app/component/TripStopsContainer.js
@@ -106,6 +106,7 @@ const containerComponent = createFragmentContainer(pureComponent, {
       longName
       mode
       type
+      url
       ...RouteAgencyInfo_route
       ...RoutePatternSelect_route @arguments(date: $date)
       alerts {

--- a/app/component/map/VehicleMarkerContainer.js
+++ b/app/component/map/VehicleMarkerContainer.js
@@ -54,8 +54,7 @@ function shouldShowVehicle(message, direction, tripStart, pattern, headsign) {
       pattern.substr(0, message.route.length) === message.route) &&
     (headsign === undefined ||
       message.headsign === undefined ||
-      // EMBARK OKC: we omit parenthese suffixes, as vehicles don't carry them
-      headsign.split(' (', 1)[0] === message.headsign.split(' (', 1)[0]) &&
+      headsign === message.headsign) &&
     (direction === undefined ||
       message.direction === undefined ||
       message.direction === direction) &&

--- a/app/configurations/config.okc.js
+++ b/app/configurations/config.okc.js
@@ -12,7 +12,6 @@ const API_URL = process.env.API_URL || 'https://otp.okc.leonard.io';
 const OTP_URL = process.env.OTP_URL || API_URL
 const GEOCODING_BASE_URL =
   process.env.GEOCODING_BASE_URL || `${API_URL}/geocoder`;
-const BUY_TICKET_URL = process.env.BUY_TICKET_URL || 'https://embarkok.com/bus/buy-passes';
 // eslint-disable-next-line no-template-curly-in-string
 const OKC_SYSTEM_MAP_URL = process.env.OKC_SYSTEM_MAP_URL || 'https://beta.embarkok.com/system-map/?config=${okcBrand}';
 
@@ -57,7 +56,6 @@ export default configMerger(walttiConfig, {
     PELIAS_PLACE: `${GEOCODING_BASE_URL}/place`,
     FONT: null,
     ROUTE_PDF: EMBARK_BASE_URL + '/assets/documents/Maps-Schedules/Route-{routeShortName}-Schedule-Map.pdf',
-    BUY_TICKET_URL: BUY_TICKET_URL,
     OKC_SYSTEM_MAP_URL: OKC_SYSTEM_MAP_URL,
   },
 

--- a/app/configurations/config.okc.js
+++ b/app/configurations/config.okc.js
@@ -55,7 +55,6 @@ export default configMerger(walttiConfig, {
     PELIAS_REVERSE_GEOCODER: `${GEOCODING_BASE_URL}/reverse`,
     PELIAS_PLACE: `${GEOCODING_BASE_URL}/place`,
     FONT: null,
-    ROUTE_PDF: EMBARK_BASE_URL + '/assets/documents/Maps-Schedules/Route-{routeShortName}-Schedule-Map.pdf',
     OKC_SYSTEM_MAP_URL: OKC_SYSTEM_MAP_URL,
   },
 

--- a/app/configurations/config.okc.js
+++ b/app/configurations/config.okc.js
@@ -249,8 +249,6 @@ export default configMerger(walttiConfig, {
     'en': 'alerts'
   },
 
-  nationalServiceLink: null,
-
   menu: {
     copyright: { label: `© Oklahoma City ${walttiConfig.YEAR}` },
     content: [

--- a/app/util/modeUtils.js
+++ b/app/util/modeUtils.js
@@ -344,6 +344,8 @@ export const getBicycleCompatibleModes = (config, modes) =>
  */
 export const modesAsOTPModes = modes =>
   modes
+    // Hot fix as somehow digitransit modes get here but should not
+    .map(mode => (mode === 'CITYBIKE' ? 'BICYCLE_RENT' : mode))
     .map(mode => mode.split('_'))
     .map(modeAndQualifier =>
       modeAndQualifier.length > 1

--- a/digitransit-component/packages/digitransit-component-control-panel/src/index.js
+++ b/digitransit-component/packages/digitransit-component-control-panel/src/index.js
@@ -324,7 +324,7 @@ function NearStopsAndRoutes({
     >
       {showTitle && (
         <h2 className={styles['near-you-title']}>
-          <Icon width="1" color="#686869" img="position" />
+          <Icon width={1} color="#686869" img="position" />
           {!modes
             ? i18next.t('title-route-stop-station', { lng: language })
             : title[language]}

--- a/sass/themes/okc/overrides.scss
+++ b/sass/themes/okc/overrides.scss
@@ -1452,3 +1452,21 @@ div.settings-section:nth-child(3) > div:nth-child(1) > fieldset:nth-child(1) > l
     line-height: 2.2;
   }
 }
+
+.mobile .route-additional-infos {
+    margin: 1px 16px 18px 16px;
+}
+
+.route-additional-infos {
+  margin: 1px 60px 18px 60px;
+  list-style: none;
+  padding-left: 0;
+
+  li {
+    padding: 5px;
+  }
+
+  li:nth-child(odd) {
+    background-color: $light-gray;
+  }
+}


### PR DESCRIPTION
## Proposed Changes
This PR
  - fixes an issue when bike rental plans where requested with the wrong (CITYBIKE) mode instead of BICYCLE_RENT
  - adds route attributes availabe als pipe-separated route.desc key-value pairs
  - uses agency.faresUrl instead of a url configured in digitransit
  - uses schedule pdf links provided via route.url instead of aa hard coded template string
  - reverts headsign comparison match that worked around different headsigns for trips in GTFS and their vehicles in GTFS-RT
  - fixes another timezone locale rendering issue
  - two minor fixes (attribute type warning and removal of duplicated nationalServiceLink setting)
